### PR TITLE
Add keyword coercion

### DIFF
--- a/src/pedestal/swagger/schema.clj
+++ b/src/pedestal/swagger/schema.clj
@@ -55,7 +55,7 @@
     :headers      {}} r))
 
 (defn coerce-params [schema value]
-  ((c/coercer (->request-schema schema) c/+string-coercions+)
+  ((c/coercer (->request-schema schema) c/string-coercion-matcher)
    (with-request-defaults value)))
 
 (defn ?bad-request


### PR DESCRIPTION
This makes it possible to use enums in schemas, like `:filter (s/enum :new :top :favorites :owner)`.