### PR TITLE
updated dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :url "http://github.com/frankiesardo/pedestal-swagger"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :plugins [[codox "0.8.10"]]
+  :plugins [[codox "0.8.11"]]
   :codox {:src-dir-uri "http://github.com/frankiesardo/pedestal-swagger/blob/master/"
           :src-linenum-anchor-prefix "L"}
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [io.pedestal/pedestal.service "0.3.0"]
+                 [io.pedestal/pedestal.service "0.3.1"]
                  [metosin/ring-swagger "0.19.5"]
                  [metosin/ring-swagger-ui "2.1.1-M1"]]
   :release-tasks [["vcs" "assert-committed"]
@@ -20,4 +20,4 @@
                   ["change" "version" "leiningen.release/bump-version"]
                   ["vcs" "commit"]
                   ["vcs" "push"]]
-  :profiles {:dev {:dependencies [[io.pedestal/pedestal.jetty "0.3.0"]]}})
+  :profiles {:dev {:dependencies [[io.pedestal/pedestal.jetty "0.3.1"]]}})

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,7 @@
           :src-linenum-anchor-prefix "L"}
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [io.pedestal/pedestal.service "0.3.0"]
-                 [metosin/ring-swagger "0.18.0"]
+                 [metosin/ring-swagger "0.19.5"]
                  [metosin/ring-swagger-ui "2.1.1-M1"]]
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]


### PR DESCRIPTION
```clojure
[io.pedestal/pedestal.service "0.3.1"] is available but we use "0.3.0"
[metosin/ring-swagger "0.19.5"] is available but we use "0.18.0"
[codox "0.8.11"] is available but we use "0.8.10"
[io.pedestal/pedestal.jetty "0.3.1"] is available but we use "0.3.0"
```

ring-swagger update fixes #7.