### PR TITLE
Implementing lenient content-negotiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ And finally we want to be able to use the schemas in the documentation to check 
 
 ```clj
 (swagger/defroutes routes
-  [[["/" ^:interceptors [(swagger/body-params)
+  [[["/" ^:interceptors [(swagger/serialise-response)
+                         (swagger/body-params)
                          (swagger/coerce-request)
                          (swagger/validate-response)]
      ["/thing/:id" ^:interceptors [load-thing-from-db]
@@ -145,13 +146,15 @@ Note that you usually need to include `(swagger/body-params)` as it will make su
 
 An interceptor with sensible error handling for most of swagger use cases is available under `pedestal.swagger.error` namespace, but you're encouraged to build your own using pedestal pattern matching.
 
+The `swagger/serialise-response` interceptor provides content-negotiation for the serialisers built in to Pedestal. You can extend it with your own content-types by passing in a map similar to `pedestal.swagger.content-negotiation/default-serialisation-interceptors`.
+
 For a complete example have a look at the `sample` project.
 
 
 ## Roadmap
 
 - Support multiple swagger.json and swagger-ui endpoints (e.g. for versioned apis)
-- Content negotiation and documenting `consumes`
+- Documenting `consumes`
 - More failures at compile time (tags not in sync, produces/consumes not in sync)
 
 ## License

--- a/sample/src/sample/service.clj
+++ b/sample/src/sample/service.clj
@@ -205,8 +205,8 @@
                             :url "http://swagger.io"}}
             {:name "orders"
              :description "Operations about orders"}]}
-    [[["/" ^:interceptors [bootstrap/json-body
-                           sw.error/handler
+    [[["/" ^:interceptors [sw.error/handler
+                           (sw/serialise-response)
                            (sw/body-params)
                            (sw/coerce-request)
                            (sw/validate-response)]

--- a/src/pedestal/swagger/content_negotiation.clj
+++ b/src/pedestal/swagger/content_negotiation.clj
@@ -1,0 +1,67 @@
+(ns pedestal.swagger.content-negotiation
+  (:require [clojure.string :as string]
+            [io.pedestal.http :as service]
+            [io.pedestal.impl.interceptor :refer [terminate]]
+            [io.pedestal.interceptor.helpers :as interceptor]
+            [linked.core :as linked]
+            [pedestal.swagger.doc :as doc]
+            [ring.util.response :as ring-response]))
+
+(def edn-body
+  (interceptor/on-response
+   ::edn-body
+   (fn [response]
+      (let [body (:body response)
+            content-type (get-in response [:headers "Content-Type"])]
+        (if (and (coll? body) (not content-type))
+          (-> response
+              (ring-response/content-type "application/edn;charset=UTF-8")
+              (assoc :body (:body (service/edn-response body))))
+          response)))))
+
+(def default-serialisation-interceptors
+  (linked/map
+   "application/json" service/json-body
+   "application/edn" edn-body
+   "application/transit+json" service/transit-json-body
+   "application/transit+msgpack" service/transit-msgpack-body
+   "application/transit" service/transit-body))
+
+(defn- find-interceptor [serialisation-interceptors accept]
+  (when-not (string/blank? accept)
+    (first
+     (for [acceptable-type (-> (string/split accept #";")
+                               first
+                               (string/split #","))
+           [type i] serialisation-interceptors
+           :when (= type acceptable-type)]
+       i))))
+
+(defn serialise-response
+  ([] (serialise-response default-serialisation-interceptors service/json-body))
+  ([serialisation-interceptors default-serialiser]
+   (doc/annotate
+    {:produces (keys serialisation-interceptors)
+     ;; :responses {406 {}} see comment below
+     }
+    (interceptor/around
+     ::serialise-response
+
+     identity
+     ;; turned off until can work out what to do with things like text/plain,text/html,image/jpg etc
+     #_(fn [{:keys [request] :as ctx}]
+         (let [accept (get-in request [:headers "accept"])]
+           (if-not (find-interceptor serialisation-interceptors accept)
+             (-> ctx
+                 terminate
+                 (assoc :response {:status 406
+                                   :headers {}
+                                   :body (format "No serialiser could be found to generate '%s'."
+                                                 accept)}))
+             ctx)))
+
+     (fn [{:keys [request] :as ctx}]
+       (if-let [i (or (find-interceptor serialisation-interceptors (get-in request [:headers "accept"]))
+                      default-serialiser)]
+         (update ctx :io.pedestal.impl.interceptor/stack conj i)
+         ctx))))))

--- a/src/pedestal/swagger/core.clj
+++ b/src/pedestal/swagger/core.clj
@@ -2,6 +2,7 @@
   (:require [pedestal.swagger.doc :as doc]
             [pedestal.swagger.schema :as schema]
             [pedestal.swagger.body-params :as body-params]
+            [pedestal.swagger.content-negotiation :as content-negotiation]
             [schema.core :as s]
             [io.pedestal.http.route.definition :refer [expand-routes]]
             [io.pedestal.interceptor.helpers :as interceptor]
@@ -91,6 +92,8 @@
      ::body-params
      (fn [{:keys [request] :as context}]
        (assoc context :request (body-params/parse-content-type parser-map request)))))))
+
+(def serialise-response content-negotiation/serialise-response)
 
 (defmacro defhandler
   "A drop-in replacement for pedestal's equivalent interceptor. Makes

--- a/src/pedestal/swagger/doc.clj
+++ b/src/pedestal/swagger/doc.clj
@@ -43,7 +43,7 @@
          (for [{:keys [path method] :as route} route-table
                :let [docs (find-docs route)]
                :when (documented-handler? route)]
-           {path {method (apply deep-merge docs)}})))
+           {path {method (apply deep-merge :into docs)}})))
 
 
 (s/defn inject-docs


### PR DESCRIPTION
Adding content negotiation for the types built in to Pedestal (json, edn, transit+json, transit+msgpack).

I've written the code to make it strict (i.e. return a `406 Not Acceptable` if we don't recognise the `Accept` header) but left it commented out because, as a "base" interceptor, it also needs to be able to serve the Swagger UI for example which requires `text/html`, `text/javascript` etc.

Also made the Swagger meta merge in a different way - now lists will concatenate so that interceptors which add to the abilities of `:consumes` or `:produces` for example are reflected in Swagger, rather than the last one winning.

Updated sample and readme.