### PR TITLE
fix delay on url-for introduced by pedestal

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,8 +4,8 @@
  :dependencies
  '[[org.clojure/clojure "1.8.0"]
 
-   [metosin/ring-swagger "0.22.14"]
-   [metosin/ring-swagger-ui "2.2.8"]
+   [metosin/ring-swagger "0.24.3"]
+   [metosin/ring-swagger-ui "3.0.17"]
 
    [adzerk/bootlaces "0.1.13" :scope "test"]
    [adzerk/boot-test "1.0.5" :scope "test"]])
@@ -16,9 +16,9 @@
 (deftask testing []
   (set-env! :source-paths #(conj % "test")
             :dependencies #(into %
-                                 '[[io.pedestal/pedestal.service "0.5.2"]
-                                   [io.pedestal/pedestal.jetty "0.5.2"]
-                                   [metosin/scjsv "0.2.0" :exclusions [org.clojure/core.async]]]))
+                                 '[[io.pedestal/pedestal.service "0.5.3"]
+                                   [io.pedestal/pedestal.jetty "0.5.3"]
+                                   [metosin/scjsv "0.4.0" :exclusions [org.clojure/core.async]]]))
   identity)
 
 (ns-unmap 'boot.user 'test)

--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
 (defproject route-swagger "Build with boot"
   :dependencies
-  [[org.clojure/clojure "1.7.0"]
-   [metosin/ring-swagger "0.22.3"]
-   [metosin/ring-swagger-ui "2.1.4-0"]]
+  [[org.clojure/clojure "1.8.0"]
+   [metosin/ring-swagger "0.24.3"]
+   [metosin/ring-swagger-ui "3.0.17"]]
   :source-paths ["src" "resources"]
-  :profiles {:dev {:dependencies [[io.pedestal/pedestal.service "0.5.2"]
-                                  [io.pedestal/pedestal.jetty "0.5.2"]
-                                  [metosin/scjsv "0.2.0" :exclusions [org.clojure/core.async]]]}})
+  :profiles {:dev {:dependencies [[io.pedestal/pedestal.service "0.5.3"]
+                                  [io.pedestal/pedestal.jetty "0.5.3"]
+                                  [metosin/scjsv "0.4.0" :exclusions [org.clojure/core.async]]]}})

--- a/src/route_swagger/interceptor.clj
+++ b/src/route_swagger/interceptor.clj
@@ -37,7 +37,7 @@
                              (case res
                                "" (redirect (str path-info "index.html"))
                                "conf.js" (response (str "window.API_CONF = {url: \""
-                                                        (apply url-for ::doc/swagger-json path-opts)
+                                                        (apply @url-for ::doc/swagger-json path-opts)
                                                         "\"};"))
                                (resource-response res {:root "swagger-ui"})))))})
 


### PR DESCRIPTION
Due to [this issue](https://github.com/pedestal/pedestal/issues/498) `url-for` is now (pedestal 0.5.3) wrapped in a `delay` which makes `swagger-ui` interceptor bug.